### PR TITLE
ci: update npm install command to use 'npm ci' for consistency

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
           cache: 'npm'
 
       - name: Install
-        run: npm install --ignore-scripts
+        run: npm ci
 
       - name: Build
         run: npm run build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         cache: 'npm'
 
     - name: Install Dependencies
-      run: npm ci --ignore-scripts
+      run: npm ci
 
     - name: Run ESLint
       run: npm run lint


### PR DESCRIPTION
This pull request updates the dependency installation commands in GitHub Actions workflows to improve consistency and reliability. The changes standardize the use of `npm ci` without the `--ignore-scripts` flag.

Workflow updates:

* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45L25-R25): Changed the `Install` step to use `npm ci` instead of `npm install --ignore-scripts` for installing dependencies.
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L23-R23): Updated the `Install Dependencies` step to use `npm ci` without the `--ignore-scripts` flag for consistency.